### PR TITLE
Adds support for soundcloud set URLs

### DIFF
--- a/mopidy_soundcloud/soundcloud.py
+++ b/mopidy_soundcloud/soundcloud.py
@@ -215,8 +215,16 @@ class SoundCloudClient(object):
 
     def parse_results(self, res):
         tracks = []
-        for track in res:
-            tracks.append(self.parse_track(track))
+        for item in res:
+            logger.debug('Parsing item %s in results...', item['kind'])
+            if item['kind'] == 'track':
+                tracks.append(self.parse_track(item))
+            elif item['kind'] == 'playlist':
+                for track in item['tracks']:
+                    logger.debug('  Parsing item %s in playlist...', track['kind'])
+                    tracks.append(self.parse_track(track))
+            else:
+                logger.warning("I don't know how to parse a '%s'.", item['kind'])
         return self.sanitize_tracks(tracks)
 
     def resolve_url(self, uri):


### PR DESCRIPTION
Adds support for soundcloud set URLs by handling kind=playlist results. Use the sc: URL scheme, e.g.

    mpc add sc:https://soundcloud.com/example/sets/whatever